### PR TITLE
Update branding assets and messaging

### DIFF
--- a/OrbusLanding/footer.html
+++ b/OrbusLanding/footer.html
@@ -3,7 +3,7 @@
         <div class="grid gap-12 lg:grid-cols-4">
             <div class="space-y-6 lg:col-span-2">
                 <a href="/" class="inline-flex items-center">
-                    <img src="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png" alt="Orbas Agency" class="h-14 w-auto drop-shadow-2xl">
+                    <img src="https://i.ibb.co/TDdxJfYJ/craiyon-040322-image.png" alt="Orbas Agency" class="h-14 w-auto drop-shadow-2xl">
                 </a>
                 <p class="text-gray-600 leading-relaxed text-base">
                     Orbas Agency pairs award-winning product craft with battle-tested conversion strategy. From positioning to launch operations, every engagement is designed to compound pipeline growth.
@@ -12,10 +12,6 @@
                     <a href="mailto:agency@orbas.io" class="hover:text-orbas-blue transition-colors inline-flex items-center gap-2" aria-label="Email Orbas Agency">
                         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M20 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm0 4-8 5-8-5V6l8 5 8-5v2z"/></svg>
                         agency@orbas.io
-                    </a>
-                    <a href="https://www.linkedin.com/company/orbas-global1/" class="hover:text-orbas-blue transition-colors inline-flex items-center gap-2" aria-label="LinkedIn">
-                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.026-3.037-1.851-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.352V9h3.414v1.561h.049c.476-.9 1.637-1.849 3.372-1.849 3.605 0 4.27 2.371 4.275 5.455v6.285zM5.337 7.433a2.062 2.062 0 1 1 0-4.124 2.062 2.062 0 0 1 0 4.124zm1.777 13.019H3.56V9h3.554v11.452z"/></svg>
-                        LinkedIn
                     </a>
                 </div>
             </div>

--- a/OrbusLanding/header.html
+++ b/OrbusLanding/header.html
@@ -3,7 +3,7 @@
         <div class="flex justify-between items-center h-16">
             <div class="flex items-center">
                 <a href="/" class="flex items-center">
-                    <img src="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png" alt="Orbas Agency logo" class="h-12 w-auto drop-shadow-lg">
+                    <img src="https://i.ibb.co/TDdxJfYJ/craiyon-040322-image.png" alt="Orbas Agency logo" class="h-12 w-auto drop-shadow-lg">
                 </a>
             </div>
             <nav class="hidden md:flex space-x-8 text-sm font-semibold">

--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -11,11 +11,11 @@
     <meta property="og:description" content="Launch faster with Orbas Agency. Premium strategy, design, development and automation with concierge-level care.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://orbas.agency/">
-    <meta property="og:image" content="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png">
+    <meta property="og:image" content="https://i.ibb.co/TDdxJfYJ/craiyon-040322-image.png">
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png">
-    <link rel="alternate icon" href="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png">
+    <link rel="icon" type="image/png" href="https://i.ibb.co/8VSNKZc/IMG-2754.png">
+    <link rel="alternate icon" href="https://i.ibb.co/8VSNKZc/IMG-2754.png">
 
     <!-- Google Fonts - Poppins -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -233,14 +233,22 @@
             </div>
             <div class="relative">
                 <div class="p-10 bg-gradient-to-br from-orbas-blue to-sky-500 rounded-3xl text-white shadow-2xl">
-                    <svg class="w-12 h-12 mb-6 text-white/80" fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M7.17 6A5.001 5.001 0 0 1 12 1a5 5 0 0 1 4.83 6.5l-.34 1A4 4 0 0 1 20 12v2a4 4 0 0 1-4 4h-4v-5a5 5 0 0 0-4.83-5.5l.34-1zM3 13a4 4 0 0 1 4-4h1a4 4 0 0 1 4 4v5H7a4 4 0 0 1-4-4v-1z" />
-                    </svg>
-                    <p class="text-lg leading-relaxed">“Orbas Agency gave us a product vision and a working platform in record time. Their team behave like co-founders—proactive, decisive and obsessed with the result.”</p>
-                    <div class="mt-6">
-                        <p class="font-semibold">Chloe Mercer</p>
-                        <p class="text-sm text-blue-100/90">Chief Product Officer, Latticewave</p>
-                    </div>
+                    <h3 class="text-2xl font-semibold mb-4">Conversion partnership commitments</h3>
+                    <p class="text-blue-100/90 leading-relaxed mb-6">We co-create every roadmap with the same principles that helped our founder deliver double-digit conversion lifts as a solo operator. When we partner with you, here’s what to expect:</p>
+                    <ul class="space-y-4 text-sm sm:text-base">
+                        <li class="flex items-start gap-3">
+                            <span class="mt-1 h-2 w-2 rounded-full bg-white"></span>
+                            North-star metrics defined up front, with weekly instrumentation reviews so every release stays accountable to revenue.
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="mt-1 h-2 w-2 rounded-full bg-white"></span>
+                            Cross-functional pods that include strategy, UX, engineering and automation specialists from day one.
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="mt-1 h-2 w-2 rounded-full bg-white"></span>
+                            Decision logs and sprint summaries delivered in plain language, keeping executives aligned without relying on testimonials.
+                        </li>
+                    </ul>
                 </div>
             </div>
         </div>
@@ -359,7 +367,7 @@
                 <p id="form-message" class="hidden text-center text-sm text-blue-100 mt-4"></p>
             </div>
             <div class="mt-10 text-center text-sm text-blue-100/80 space-y-2">
-                <p>Prefer a direct chat? Message us on LinkedIn and we’ll respond within minutes.</p>
+                <p>Prefer a direct chat? Email us or request a WhatsApp introduction in your message and we’ll respond within minutes.</p>
                 <p>Email <a href="mailto:agency@orbas.io" class="underline">agency@orbas.io</a> · Press <a href="mailto:press@orbas.io" class="underline">press@orbas.io</a></p>
             </div>
         </div>

--- a/OrbusLanding/privacy/index.html
+++ b/OrbusLanding/privacy/index.html
@@ -8,8 +8,8 @@
     <meta name="robots" content="index, follow">
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png">
-    <link rel="alternate icon" href="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png">
+    <link rel="icon" type="image/png" href="https://i.ibb.co/8VSNKZc/IMG-2754.png">
+    <link rel="alternate icon" href="https://i.ibb.co/8VSNKZc/IMG-2754.png">
 
     <!-- Google Fonts - Poppins -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- replace the header, footer, and open graph branding with the provided logo asset
- swap the favicon for the supplied image across the site, including the privacy policy
- remove LinkedIn references, replacing the testimonial card with commitment messaging and updating direct-contact copy

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e5db798f1c8320b4487bb6b56ca01a